### PR TITLE
Wip/cross vivado support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ In theory most boards can be supported. However, you can find here a list of boa
 
 ## Vivado version tested
 
- - [x] Vivado 2022.2.2
+ - [x] Vivado 2024.1
+ - [x] Vivado 2022.2
 
 **Let us know** if it works for you with another version!
 
+See [How to add suport for a Vivado version](doc/add_vivado_version_support.md) section for further information on how to extend the library.
 
 ## How to use the library (guidelines)
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,13 +6,15 @@ val spinalVersion = "1.12.0"
 val spinalCore = "com.github.spinalhdl" %% "spinalhdl-core" % spinalVersion
 val spinalLib = "com.github.spinalhdl" %% "spinalhdl-lib" % spinalVersion
 val spinalIdslPlugin = compilerPlugin("com.github.spinalhdl" %% "spinalhdl-idsl-plugin" % spinalVersion)
+val upickle = "com.lihaoyi" %% "upickle" % "4.1.0"
+val oslib = "com.lihaoyi" %% "os-lib" % "0.11.3"
 
 lazy val lib = (project in file("."))
   .settings(
     name := "ultrascale-spinal-wrapper",
     Compile / scalaSource := baseDirectory.value / "hw" / "spinal",
     Compile / resourceDirectory := baseDirectory.value / "hw" / "ext",
-    libraryDependencies ++= Seq(spinalCore, spinalLib, spinalIdslPlugin)
+    libraryDependencies ++= Seq(spinalCore, spinalLib, spinalIdslPlugin, upickle, oslib)
   )
 
 fork := true

--- a/doc/add_vivado_version_support.md
+++ b/doc/add_vivado_version_support.md
@@ -2,7 +2,7 @@
 
 As we found out, the main difference between one version to another is the IPs versions.
 As most of the TCL script generation logic can be kept and re-use, the library uses a simple JSOM file as database to store the relevant IPs versions for each vivado version.
-The database in question named `VivadoIPVersion.json` can be found in `hw/ext/`.
+The database in question named `VivadoIPVersion.json` can be found in `hw/ext/` (see [file](../hw/ext/VivadoIPVersion.json)).
 
 The JSON file structure is as follows:
 ```json

--- a/doc/add_vivado_version_support.md
+++ b/doc/add_vivado_version_support.md
@@ -1,0 +1,29 @@
+# Adding support for other Vivado versions
+
+As we found out, the main difference between one version to another is the IPs versions.
+As most of the TCL script generation logic can be kept and re-use, the library uses a simple JSOM file as database to store the relevant IPs versions for each vivado version.
+The database in question named `VivadoIPVersion.json` can be found in `hw/ext/`.
+
+The JSON file structure is as follows:
+```json
+{
+    "<vivado-version-1>" : {
+        "zynq_ultra_ps_e" : "<zynq-ip-version-1>",
+        "proc_sys_reset"  : "<reset-sys-ip-version-1>"
+    },
+    "<vivado-version-2>" : {
+        "zynq_ultra_ps_e" : "<zynq-ip-version-2>",
+        "proc_sys_reset"  : "<reset-sys-ip-version-2>"
+    },
+    ...
+    "<vivado-version-n>" : {
+        "zynq_ultra_ps_e" : "<zynq-ip-version-n>",
+        "proc_sys_reset"  : "<reset-sys-ip-version-n>"
+    },
+}
+```
+Where:
+ - `<vivado-version-X>` is the version of vivado printed when typing `vivado -version` in your terminal. It should be foru digits (i.e., a year) followed by a signle digit (i.e., a revision number).
+ - `<zynq-ip-version-X>` is the version of the zynq IP for the associated vivado version. The information can be found in the vivado's IPs library.
+ - `<sys-reset-ip-version-X>` is the version of the system reset IP for the associated vivado version. The information can be found in the vivado's IPs library.
+

--- a/hw/ext/VivadoIPVersion.json
+++ b/hw/ext/VivadoIPVersion.json
@@ -1,0 +1,10 @@
+{ 
+  "2024.1" : {
+    "zynq_ultra_ps_e" : "3.5",
+    "proc_sys_reset"  : "5.0"
+  },
+  "2022.2" : {
+    "zynq_ultra_ps_e" : "3.4",
+    "proc_sys_reset"  : "5.0"
+  }
+}

--- a/hw/spinal/ultrascaleplus/UltraScalePlus.scala
+++ b/hw/spinal/ultrascaleplus/UltraScalePlus.scala
@@ -13,9 +13,6 @@ package ultrascaleplus
  package object scaladoc {}
 
 
-import Console.{RESET, YELLOW}
-
-
 import spinal.core._
 import spinal.lib._
 import spinal.lib.bus.amba4.axi._
@@ -103,7 +100,7 @@ abstract class UltraScalePlus (
   val differences = availableFrequencies.map(x => (x-frequency).toDouble).map(x => if (x > 0) -1.0/0 else x)
   val index       = differences.indexOf(differences.max)
   frequency       = availableFrequencies(index)
-  println(f"${RESET}${YELLOW}[UltraScale+ Wrapper] Actual frequency set is ${frequency}.${RESET}")
+  Log.info(f"Actual frequency set is ${frequency}.")
   
   // Components name for TCL
   val board: String

--- a/hw/spinal/ultrascaleplus/UltraScalePlus.scala
+++ b/hw/spinal/ultrascaleplus/UltraScalePlus.scala
@@ -12,6 +12,7 @@ package ultrascaleplus
   */
  package object scaladoc {}
 
+
 import Console.{RESET, YELLOW}
 
 
@@ -89,9 +90,12 @@ class UltraScalePlusIO(config: UltraScalePlusConfig) extends Bundle {
 
 
 abstract class UltraScalePlus (
-  var frequency: HertzNumber          = 99.999001 MHz,
-  val config   : UltraScalePlusConfig = new UltraScalePlusConfig()
+  var vivadoVersion: String               = "auto",
+  var frequency    : HertzNumber          = 99.999001 MHz,
+  val config       : UltraScalePlusConfig = new UltraScalePlusConfig()
 ) extends Component with TCL {
+
+  Vivado(vivadoVersion)
 
   // List of IOPLL clocks available for UltraScale+
   val availableFrequencies = Seq(333.329987 MHz, 299.997009 MHz, 249.997498 MHz, 199.998001 MHz, 142.855713 MHz, 99.999001 MHz, 49.999500 MHz)
@@ -108,7 +112,7 @@ abstract class UltraScalePlus (
 
   def getTCL(): String = {
     var tcl = ""
-    tcl += "set processing_system [ create_bd_cell -type ip -vlnv xilinx.com:ip:zynq_ultra_ps_e:3.4 processing_system ]\n"
+    tcl +=f"set processing_system [ create_bd_cell -type ip -vlnv xilinx.com:ip:zynq_ultra_ps_e:${Vivado.getIPVersion("zynq_ultra_ps_e")} processing_system ]\n"
     tcl += "set_property -dict [list \\\n"
     tcl += "  CONFIG.PSU_BANK_0_IO_STANDARD {LVCMOS18} \\\n"
     tcl += "  CONFIG.PSU_BANK_1_IO_STANDARD {LVCMOS18} \\\n"

--- a/hw/spinal/ultrascaleplus/Utils.scala
+++ b/hw/spinal/ultrascaleplus/Utils.scala
@@ -1,6 +1,9 @@
 package ultrascaleplus.utils
 
 
+import Console.{RESET, YELLOW}
+
+
 import spinal.lib.bus.misc.SizeMapping
 
 
@@ -48,3 +51,12 @@ trait XDC {
 
 
 class Aperture(val name: String, base: BigInt, size: BigInt) extends SizeMapping(base, size) {}
+
+
+object Log {
+
+  def info(message: String): Unit = {
+    println(f"${RESET}${YELLOW}[UltraScale+] ${message}${RESET}")
+  }
+
+}

--- a/hw/spinal/ultrascaleplus/Vivado.scala
+++ b/hw/spinal/ultrascaleplus/Vivado.scala
@@ -3,22 +3,14 @@ package ultrascaleplus
 import Console.{RESET, YELLOW}
 import sys.process._
 import scala.util.matching.Regex
+import upickle.default._
 
 
 object Vivado {
 
   var version: String = null
 
-  def IPVersionMap: Map[String, Map[String, String]] = Map(
-    "2024.1" -> Map(
-      "zynq_ultra_ps_e" -> "3.5",
-      "proc_sys_reset"  -> "5.0"
-    ),
-    "2022.2" -> Map(
-      "zynq_ultra_ps_e" -> "3.4",
-      "proc_sys_reset"  -> "5.0"
-    )
-  )
+  val IPVersionMap= read[Map[String, Map[String, String]]](os.read(os.pwd / "hw/ext/VivadoIPVersion.json"))
 
   def supportedVivadoVersions: Seq[String] = {
     return IPVersionMap.keys.toSeq

--- a/hw/spinal/ultrascaleplus/Vivado.scala
+++ b/hw/spinal/ultrascaleplus/Vivado.scala
@@ -1,0 +1,73 @@
+package ultrascaleplus
+
+import Console.{RESET, YELLOW}
+import sys.process._
+import scala.util.matching.Regex
+
+
+object Vivado {
+
+  var version: String = null
+
+  def IPVersionMap: Map[String, Map[String, String]] = Map(
+    "2024.1" -> Map(
+      "zynq_ultra_ps_e" -> "3.5",
+      "proc_sys_reset"  -> "5.0"
+    ),
+    "2022.2" -> Map(
+      "zynq_ultra_ps_e" -> "3.4",
+      "proc_sys_reset"  -> "5.0"
+    )
+  )
+
+  def supportedVivadoVersions: Seq[String] = {
+    return IPVersionMap.keys.toSeq
+  }
+
+  def getIPVersion(ip: String): String = {
+    return IPVersionMap(this.version)(ip)
+  }
+
+  def detectVivadoVersion(): String = {
+    var detectedVersion = ""
+    // Execute bash command and get output in string
+    try {
+      val versionCommandOutput = Seq("vivado", "-version").!!
+      // Extract version from pattern
+      val versionPattern = "v([0-9]*.[0-9])".r
+      versionPattern.findFirstMatchIn(versionCommandOutput) match {
+        case Some(m) => detectedVersion = m.group(1)
+        case None    => throw new Exception("")
+      }
+    }
+    catch {
+      case e: java.io.IOException        => { println(f"${RESET}${YELLOW}[UltraScale+ Wrapper] No Vivado install found... Make sure to source your install 'settings.sh'!${RESET}") }
+      case e: java.lang.RuntimeException => { println(f"${RESET}${YELLOW}[UltraScale+ Wrapper] Calling 'vivado -version' failed... Make sure to source your install 'settings.sh'!${RESET}") }
+      case e: Exception                  => { println(f"${RESET}${YELLOW}[UltraScale+ Wrapper] Vivado install found but no version could be inferred from command line!${RESET}") }
+      System.exit(-1);
+    }
+    return detectedVersion
+  }
+  
+  def apply(targetVersion: String = "auto"): Unit = {
+    this.version = this.detectVivadoVersion()
+    // Report to user on specified version and detected one
+    if (targetVersion == "auto") {
+      println(f"${RESET}${YELLOW}[UltraScale+ Wrapper] Vivado version ${this.version} detected and picked!${RESET}")
+    }
+    else if (supportedVivadoVersions contains targetVersion) {
+      if (targetVersion != this.version) {
+        this.version = targetVersion
+        println(f"${RESET}${YELLOW}[UltraScale+ Wrapper] Vivado version ${version} specified but version ${this.version} detected! (v${this.version} conserved for TCl script generation)${RESET}")
+      }
+      else {
+        println(f"${RESET}${YELLOW}[UltraScale+ Wrapper] Vivado version ${version} specified and detected!${RESET}")
+      }
+    }
+    else {
+        println(f"${RESET}${YELLOW}[UltraScale+ Wrapper] Requested vivado version (v${targetVersion}) is not supported!${RESET}")
+        System.exit(-1)
+    }
+  }
+
+}

--- a/hw/spinal/ultrascaleplus/Vivado.scala
+++ b/hw/spinal/ultrascaleplus/Vivado.scala
@@ -1,9 +1,12 @@
 package ultrascaleplus
 
-import Console.{RESET, YELLOW}
+
 import sys.process._
 import scala.util.matching.Regex
 import upickle.default._
+
+
+import ultrascaleplus.utils.Log
 
 
 object Vivado {
@@ -33,9 +36,15 @@ object Vivado {
       }
     }
     catch {
-      case e: java.io.IOException        => { println(f"${RESET}${YELLOW}[UltraScale+ Wrapper] No Vivado install found... Make sure to source your install 'settings.sh'!${RESET}") }
-      case e: java.lang.RuntimeException => { println(f"${RESET}${YELLOW}[UltraScale+ Wrapper] Calling 'vivado -version' failed... Make sure to source your install 'settings.sh'!${RESET}") }
-      case e: Exception                  => { println(f"${RESET}${YELLOW}[UltraScale+ Wrapper] Vivado install found but no version could be inferred from command line!${RESET}") }
+      case e: java.io.IOException => {
+        Log.info("No Vivado install found... Make sure to source your install 'settings.sh'!")
+      }
+      case e: java.lang.RuntimeException => {
+        Log.info("Calling 'vivado -version' failed... Make sure to source your install 'settings.sh'!")
+      }
+      case e: Exception => {
+        Log.info("Vivado install found but no version could be inferred from command line!")
+      }
       System.exit(-1);
     }
     return detectedVersion
@@ -45,20 +54,20 @@ object Vivado {
     this.version = this.detectVivadoVersion()
     // Report to user on specified version and detected one
     if (targetVersion == "auto") {
-      println(f"${RESET}${YELLOW}[UltraScale+ Wrapper] Vivado version ${this.version} detected and picked!${RESET}")
+      Log.info(f"Vivado version ${this.version} detected and picked!")
     }
     else if (supportedVivadoVersions contains targetVersion) {
       if (targetVersion != this.version) {
         this.version = targetVersion
-        println(f"${RESET}${YELLOW}[UltraScale+ Wrapper] Vivado version ${version} specified but version ${this.version} detected! (v${this.version} conserved for TCl script generation)${RESET}")
+        Log.info(f"$Vivado version ${version} specified but version ${this.version} detected! (v${this.version} conserved for TCl script generation)")
       }
       else {
-        println(f"${RESET}${YELLOW}[UltraScale+ Wrapper] Vivado version ${version} specified and detected!${RESET}")
+        Log.info(f"Vivado version ${version} specified and detected!")
       }
     }
     else {
-        println(f"${RESET}${YELLOW}[UltraScale+ Wrapper] Requested vivado version (v${targetVersion}) is not supported!${RESET}")
-        System.exit(-1)
+      Log.info(f"Requested vivado version (v${targetVersion}) is not supported!")
+      System.exit(-1)
     }
   }
 

--- a/hw/spinal/ultrascaleplus/scripts/TCLFactory.scala
+++ b/hw/spinal/ultrascaleplus/scripts/TCLFactory.scala
@@ -38,7 +38,7 @@ object TCLFactory {
     tcl +=  "set proj_dir [get_property directory [current_project]]\n"
     tcl +=  "\n"
     tcl +=  "set obj [current_project]\n"
-    tcl +=  setProperty("board_part_repo_paths", "[file normalize \"~/.Xilinx/Vivado/2022.2/xhub/board_store/xilinx_board_store\"]" , "$obj")
+    tcl +=  setProperty("board_part_repo_paths", f"[file normalize \"~/.Xilinx/Vivado/${Vivado.version}/xhub/board_store/xilinx_board_store\"]" , "$obj")
     tcl +=  setProperty("board_part", f"xilinx.com:${this.platform.get.board}:part0:${this.platform.get.version}", "$obj")
     tcl +=  setProperty("default_lib", "xil_defaultlib", "$obj")
     tcl +=  setProperty("enable_resource_estimation", "0", "$obj")
@@ -105,7 +105,7 @@ object TCLFactory {
 
   def checkIPs(): String = {
     var tcl = ""
-    tcl += "set list_check_ips \"xilinx.com:ip:proc_sys_reset:5.0 xilinx.com:ip:zynq_ultra_ps_e:3.4\"\n"
+    tcl +=f"set list_check_ips \"xilinx.com:ip:proc_sys_reset:5.0 xilinx.com:ip:zynq_ultra_ps_e:${Vivado.getIPVersion("zynq_ultra_ps_e")}\"\n"
     tcl += "set list_ips_missing \"\"\n"
     tcl += "foreach ip_vlnv $list_check_ips {\n"
     tcl += "  set ip_obj [get_ipdefs -all $ip_vlnv]\n"


### PR DESCRIPTION
This pull request introduces support for multiple version of Vivado (currently: 2022.2 and 2024.1). The provided constructs is built to be flexible and easily extensible.

Between, v2022.2 and v2024.1, the main difference observed is the vivado-originated IPs' (i.e., zynq and system_reset) version. But for these, the TCL script generated by the `TCLFactory` seems to work seamlessly. Thus, emphasis was solely put on managing IPs' version for each vivado version.

At the core, we have one object named `Vivado`. It acts as a smart `Map` in the sense that it maps an IP (a String) to a version (also a String). The selection of the vivado version (and consequently the aforementioned mapping) is done in two ways:
 1. Automatically detected by the `Vivado` object itself at the bring-up of the project.
 2. Specified by the user. Currently, set in the constructor of the `UltraScalePlus` class. This way, we ensure that a local installation of vivado is not necessary top generate the Verilog/VHDL code.

For ease of use and flexibility, the Vivado version to IPs to IP's version is stored in a JSON in the `hw/ext/` folder. 

One point remain to be decided: where to place the first call  to the `Vivado object`. I have two ideas:
 1. It remains in the `UltraScalePlus` class, that way the exact version can be part of the top-module constructor's parameters.
 2. It is moved to the `Config` object as part of a fixed set of specifications.