### PR TITLE
How to set a Vivado version for generation

### DIFF
--- a/doc/set_vivado_version.md
+++ b/doc/set_vivado_version.md
@@ -1,0 +1,19 @@
+# Set Vivado version for HDL generation
+
+## Target vivado version is locally installed
+
+The easiest way is to source the proper vivado version and keep the `Config.vivado` set to "auto".
+In other words, make sure to:
+```bash
+source /vivado/install/folder/version/settings.sh
+```
+
+Otherwise, see next section.
+
+## Target vivado version is not locally installed
+
+As early as possible in your top module descrtiption, add
+```bash
+Config.vivado = "2022.2"
+```
+for instance.

--- a/hw/spinal/ultrascaleplus/Config.scala
+++ b/hw/spinal/ultrascaleplus/Config.scala
@@ -1,4 +1,4 @@
-package example
+package ultrascaleplus
 
 import spinal.core._
 import spinal.core.sim._
@@ -13,4 +13,9 @@ object Config {
   )
 
   def sim = SimConfig.withConfig(spinal).withFstWave
+
+  /**
+   * Desired vivado version
+   */
+  var vivado = "auto"
 }

--- a/hw/spinal/ultrascaleplus/UltraScalePlus.scala
+++ b/hw/spinal/ultrascaleplus/UltraScalePlus.scala
@@ -87,12 +87,9 @@ class UltraScalePlusIO(config: UltraScalePlusConfig) extends Bundle {
 
 
 abstract class UltraScalePlus (
-  var vivadoVersion: String               = "auto",
   var frequency    : HertzNumber          = 99.999001 MHz,
   val config       : UltraScalePlusConfig = new UltraScalePlusConfig()
 ) extends Component with TCL {
-
-  Vivado(vivadoVersion)
 
   // List of IOPLL clocks available for UltraScale+
   val availableFrequencies = Seq(333.329987 MHz, 299.997009 MHz, 249.997498 MHz, 199.998001 MHz, 142.855713 MHz, 99.999001 MHz, 49.999500 MHz)

--- a/hw/spinal/ultrascaleplus/Vivado.scala
+++ b/hw/spinal/ultrascaleplus/Vivado.scala
@@ -11,19 +11,33 @@ import ultrascaleplus.utils.Log
 
 object Vivado {
 
-  var version: String = null
+  private var targetVersion: String = null
+  
+  private val IPVersionMap = read[Map[String, Map[String, String]]](os.read(os.pwd / "hw/ext/VivadoIPVersion.json"))
 
-  val IPVersionMap= read[Map[String, Map[String, String]]](os.read(os.pwd / "hw/ext/VivadoIPVersion.json"))
+  private def setVersionIfNotDefined(): Unit = {
+    if (targetVersion == null) {
+      // Report to user on specified version and detected one
+      if (Config.vivado == "auto") {
+        targetVersion = this.detectVivadoVersion()
+        Log.info(f"Vivado version ${this.version} detected and picked!")
+      }
+      else if (supportedVivadoVersions contains Config.vivado) {
+        targetVersion = Config.vivado
+        Log.info(f"$Vivado version ${targetVersion} will be used as specified!")
+      }
+      else {
+        Log.info(f"Requested vivado version (v${targetVersion}) is not supported!")
+        System.exit(-1)
+      }
+    }
+  } 
 
-  def supportedVivadoVersions: Seq[String] = {
+  private def supportedVivadoVersions: Seq[String] = {
     return IPVersionMap.keys.toSeq
   }
 
-  def getIPVersion(ip: String): String = {
-    return IPVersionMap(this.version)(ip)
-  }
-
-  def detectVivadoVersion(): String = {
+  private def detectVivadoVersion(): String = {
     var detectedVersion = ""
     // Execute bash command and get output in string
     try {
@@ -50,25 +64,14 @@ object Vivado {
     return detectedVersion
   }
   
-  def apply(targetVersion: String = "auto"): Unit = {
-    this.version = this.detectVivadoVersion()
-    // Report to user on specified version and detected one
-    if (targetVersion == "auto") {
-      Log.info(f"Vivado version ${this.version} detected and picked!")
-    }
-    else if (supportedVivadoVersions contains targetVersion) {
-      if (targetVersion != this.version) {
-        this.version = targetVersion
-        Log.info(f"$Vivado version ${version} specified but version ${this.version} detected! (v${this.version} conserved for TCl script generation)")
-      }
-      else {
-        Log.info(f"Vivado version ${version} specified and detected!")
-      }
-    }
-    else {
-      Log.info(f"Requested vivado version (v${targetVersion}) is not supported!")
-      System.exit(-1)
-    }
+  def version: String = {
+    this.setVersionIfNotDefined()
+    return this.targetVersion
+  }
+  
+  def getIPVersion(ip: String): String = {
+    this.setVersionIfNotDefined()
+    return IPVersionMap(this.targetVersion)(ip)
   }
 
 }


### PR DESCRIPTION
Now, a version of vivado to be used must be precised in the Config object.
The version can be changed by the user by setting `Config.vivado` to the desired version.

The behavior of the `Vivado` object has been altered:
 1. the vivado object looks it up and in case of auto,
 2. detect the version wanted and, 
 3. make sure a version is set when a method is called.

Moreover, quick documentation was added.