### PR TITLE
Wip/clock refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,16 @@
 *.log
 *.bak
 
+# vivado
+vivado/
+*.log
+*.jou
+*.str
+*.zip
+*.bit
+*.bin
+*.xsa
+
 # sbt specific
 .cache/
 .history/
@@ -45,8 +55,3 @@ bin/
 simWorkspace/
 tmp/
 null
-
-vivado/
-vivado.log
-vivado.jou
-*.bit

--- a/hw/spinal/example/kr260/ConfigPortTest.scala
+++ b/hw/spinal/example/kr260/ConfigPortTest.scala
@@ -10,11 +10,12 @@ import ultrascaleplus.bus.amba.axi4._
 import ultrascaleplus.scripts._
 import ultrascaleplus.configport._
 import ultrascaleplus.clock._
+import ultrascaleplus.clock.pll._
 
 
 case class ConfigPortTest() extends KR260(
   config    = new KR260Config(
-    withPL_CLK0  = 100 MHz,
+    withPL_CLK0  = PLL.IO(100 MHz),
     withLPD_HPM0 = true
   )
 ) {

--- a/hw/spinal/example/kr260/Shell.scala
+++ b/hw/spinal/example/kr260/Shell.scala
@@ -6,6 +6,7 @@ import spinal.lib._
 
 
 import ultrascaleplus.clock._
+import ultrascaleplus.clock.pll._
 
 
 import kr260._
@@ -13,10 +14,10 @@ import kr260._
 
 case class Shell() extends KR260(
   config    = new KR260Config(
-    withPL_CLK0    = 332 MHz,
-    withPL_CLK1    = 332 MHz,
-    withPL_CLK2    = 332 MHz,
-    withPL_CLK3    = 332 MHz,
+    withPL_CLK0    = PLL.IO(332 MHz),
+    withPL_CLK1    = PLL.IO(332 MHz),
+    withPL_CLK2    = PLL.IO(332 MHz),
+    withPL_CLK3    = PLL.IO(332 MHz),
     withLPD_HPM0   =    true,
     withLPD_HP0    =    true,
     withFPD_HPM0   =    true,

--- a/hw/spinal/example/kv260/ConfigPortTest.scala
+++ b/hw/spinal/example/kv260/ConfigPortTest.scala
@@ -10,11 +10,12 @@ import ultrascaleplus.bus.amba.axi4._
 import ultrascaleplus.scripts._
 import ultrascaleplus.configport._
 import ultrascaleplus.clock._
+import ultrascaleplus.clock.pll._
 
 
 case class ConfigPortTest() extends KV260(
   config    = new KV260Config(
-    withPL_CLK0  = 100 MHz,
+    withPL_CLK0  = PLL.IO(100 MHz),
     withLPD_HPM0 = true
   )
 ) {

--- a/hw/spinal/example/kv260/Shell.scala
+++ b/hw/spinal/example/kv260/Shell.scala
@@ -17,7 +17,7 @@ case class Shell() extends KV260(
     withPL_CLK0    = PLL.IO(340 MHz),
     withPL_CLK1    = PLL.IO(300 MHz),
     withPL_CLK2    = PLL.IO(250 MHz),
-    withPL_CLK3    = PLL.IO( 75 MHz),
+    withPL_CLK3    = PLL.R( 75 MHz),
     withLPD_HPM0   =    true,
     withLPD_HP0    =    true,
     withFPD_HPM0   =    true,

--- a/hw/spinal/example/kv260/Shell.scala
+++ b/hw/spinal/example/kv260/Shell.scala
@@ -6,6 +6,7 @@ import spinal.lib._
 
 
 import ultrascaleplus.clock._
+import ultrascaleplus.clock.pll._
 
 
 import kv260._
@@ -13,10 +14,10 @@ import kv260._
 
 case class Shell() extends KV260(
   config    = new KV260Config(
-    withPL_CLK0    = 332 MHz,
-    withPL_CLK1    = 332 MHz,
-    withPL_CLK2    = 332 MHz,
-    withPL_CLK3    = 332 MHz,
+    withPL_CLK0    = PLL.IO(340 MHz),
+    withPL_CLK1    = PLL.IO(300 MHz),
+    withPL_CLK2    = PLL.IO(250 MHz),
+    withPL_CLK3    = PLL.IO( 75 MHz),
     withLPD_HPM0   =    true,
     withLPD_HP0    =    true,
     withFPD_HPM0   =    true,

--- a/hw/spinal/example/zcu102/ConfigPortTest.scala
+++ b/hw/spinal/example/zcu102/ConfigPortTest.scala
@@ -10,11 +10,12 @@ import ultrascaleplus.bus.amba.axi4._
 import ultrascaleplus.scripts._
 import ultrascaleplus.configport._
 import ultrascaleplus.clock._
+import ultrascaleplus.clock.pll._
 
 
 case class ConfigPortTest() extends ZCU102(
   config    = new ZCU102Config(
-    withPL_CLK0  = 100 MHz,
+    withPL_CLK0  = PLL.IO(100 MHz),
     withLPD_HPM0 = true
   )
 ) {

--- a/hw/spinal/example/zcu102/Shell.scala
+++ b/hw/spinal/example/zcu102/Shell.scala
@@ -6,6 +6,7 @@ import spinal.lib._
 
 
 import ultrascaleplus.clock._
+import ultrascaleplus.clock.pll._
 
 
 import zcu102._
@@ -13,10 +14,10 @@ import zcu102._
 
 case class Shell() extends ZCU102(
   config    = new ZCU102Config(
-    withPL_CLK0    =    332 MHz,
-    withPL_CLK1    =    332 MHz,
-    withPL_CLK2    =    332 MHz,
-    withPL_CLK3    =    332 MHz,
+    withPL_CLK0    = PLL.IO(332 MHz),
+    withPL_CLK1    = PLL.IO(332 MHz),
+    withPL_CLK2    = PLL.IO(332 MHz),
+    withPL_CLK3    = PLL.IO(332 MHz),
     withLPD_HPM0   =       true,
     withLPD_HP0    =       true,
     withFPD_HPM0   =       true,

--- a/hw/spinal/kr260/KR260.scala
+++ b/hw/spinal/kr260/KR260.scala
@@ -12,42 +12,43 @@ import ultrascaleplus.bus.amba.axi4._
 import ultrascaleplus.io.pmod._
 import ultrascaleplus.scripts._
 import ultrascaleplus.clock.PLClockingArea
+import ultrascaleplus.clock.pll._
 import kr260.io.pmod._
 
 
 class KR260Config(
-  withPL_CLK0    : HertzNumber = 100 MHz,
-  withPL_CLK1    : HertzNumber =   0 MHz,
-  withPL_CLK2    : HertzNumber =   0 MHz,
-  withPL_CLK3    : HertzNumber =   0 MHz,
-  withLPD_HPM0   : Boolean     = false,
-  withLPD_HP0    : Boolean     = false,
-  withFPD_HPM0   : Boolean     = false,
-  withFPD_HPM1   : Boolean     = false,
-  withFPD_HP0    : Boolean     = false,
-  withFPD_HP1    : Boolean     = false,
-  withFPD_HP2    : Boolean     = false,
-  withFPD_HP3    : Boolean     = false,
-  withFPD_HPC0   : Boolean     = false,
-  withFPD_HPC1   : Boolean     = false,
-  withFPD_ACP    : Boolean     = false,
-  withFPD_ACE    : Boolean     = false,
-  withDBG_CTI0   : Boolean     = false,
-  withDBG_CTI1   : Boolean     = false,
-  withDBG_CTI2   : Boolean     = false,
-  withDBG_CTI3   : Boolean     = false,
-  withDBG_CTO0   : Boolean     = false,
-  withDBG_CTO1   : Boolean     = false,
-  withDBG_CTO2   : Boolean     = false,
-  withDBG_CTO3   : Boolean     = false,
-  withPL_PS_IRQ0 : Int         =     0,
-  withPL_PS_IRQ1 : Int         =     0,
-  withTRACE      : Boolean     = false,
+  withPL_CLK0    : PLL      = PLL.IO(100 MHz),
+  withPL_CLK1    : PLL      = PLL.IO(  0 MHz),
+  withPL_CLK2    : PLL      = PLL.IO(  0 MHz),
+  withPL_CLK3    : PLL      = PLL.IO(  0 MHz),
+  withLPD_HPM0   : Boolean  = false,
+  withLPD_HP0    : Boolean  = false,
+  withFPD_HPM0   : Boolean  = false,
+  withFPD_HPM1   : Boolean  = false,
+  withFPD_HP0    : Boolean  = false,
+  withFPD_HP1    : Boolean  = false,
+  withFPD_HP2    : Boolean  = false,
+  withFPD_HP3    : Boolean  = false,
+  withFPD_HPC0   : Boolean  = false,
+  withFPD_HPC1   : Boolean  = false,
+  withFPD_ACP    : Boolean  = false,
+  withFPD_ACE    : Boolean  = false,
+  withDBG_CTI0   : Boolean  = false,
+  withDBG_CTI1   : Boolean  = false,
+  withDBG_CTI2   : Boolean  = false,
+  withDBG_CTI3   : Boolean  = false,
+  withDBG_CTO0   : Boolean  = false,
+  withDBG_CTO1   : Boolean  = false,
+  withDBG_CTO2   : Boolean  = false,
+  withDBG_CTO3   : Boolean  = false,
+  withPL_PS_IRQ0 : Int      =     0,
+  withPL_PS_IRQ1 : Int      =     0,
+  withTRACE      : Boolean  = false,
   // here
-  val withIO_PMOD0: Boolean    = false,
-  val withIO_PMOD1: Boolean    = false,
-  val withIO_PMOD2: Boolean    = false,
-  val withIO_PMOD3: Boolean    = false
+  val withIO_PMOD0: Boolean = false,
+  val withIO_PMOD1: Boolean = false,
+  val withIO_PMOD2: Boolean = false,
+  val withIO_PMOD3: Boolean = false
   ) extends UltraScalePlusConfig(
     withPL_CLK0    = withPL_CLK0   ,
     withPL_CLK1    = withPL_CLK1   ,
@@ -89,7 +90,7 @@ class KR260IO(config: KR260Config) extends UltraScalePlusIO(config) {
 
 class KR260(
   override val config   : KR260Config = new KR260Config(
-    withPL_CLK0 = 100 MHz
+    withPL_CLK0 = PLL.IO(100 MHz)
   )
 ) extends UltraScalePlus(
   config    = config

--- a/hw/spinal/kv260/KV260.scala
+++ b/hw/spinal/kv260/KV260.scala
@@ -12,37 +12,38 @@ import ultrascaleplus.bus.amba.axi4._
 import ultrascaleplus.io.pmod._
 import ultrascaleplus.scripts._
 import ultrascaleplus.clock.PLClockingArea
+import ultrascaleplus.clock.pll._
 import kv260.io.pmod._
 
 
 class KV260Config(
-  withPL_CLK0    : HertzNumber = 100 MHz,
-  withPL_CLK1    : HertzNumber =   0 MHz,
-  withPL_CLK2    : HertzNumber =   0 MHz,
-  withPL_CLK3    : HertzNumber =   0 MHz,
-  withLPD_HPM0   : Boolean     = false,
-  withLPD_HP0    : Boolean     = false,
-  withFPD_HPM0   : Boolean     = false,
-  withFPD_HPM1   : Boolean     = false,
-  withFPD_HP0    : Boolean     = false,
-  withFPD_HP1    : Boolean     = false,
-  withFPD_HP2    : Boolean     = false,
-  withFPD_HP3    : Boolean     = false,
-  withFPD_HPC0   : Boolean     = false,
-  withFPD_HPC1   : Boolean     = false,
-  withFPD_ACP    : Boolean     = false,
-  withFPD_ACE    : Boolean     = false,
-  withDBG_CTI0   : Boolean     = false,
-  withDBG_CTI1   : Boolean     = false,
-  withDBG_CTI2   : Boolean     = false,
-  withDBG_CTI3   : Boolean     = false,
-  withDBG_CTO0   : Boolean     = false,
-  withDBG_CTO1   : Boolean     = false,
-  withDBG_CTO2   : Boolean     = false,
-  withDBG_CTO3   : Boolean     = false,
-  withPL_PS_IRQ0 : Int         =     0,
-  withPL_PS_IRQ1 : Int         =     0,
-  withTRACE      : Boolean     = false,
+  withPL_CLK0    : PLL      = PLL.IO(100 MHz),
+  withPL_CLK1    : PLL      = PLL.IO(  0 MHz),
+  withPL_CLK2    : PLL      = PLL.IO(  0 MHz),
+  withPL_CLK3    : PLL      = PLL.IO(  0 MHz),
+  withLPD_HPM0   : Boolean  = false,
+  withLPD_HP0    : Boolean  = false,
+  withFPD_HPM0   : Boolean  = false,
+  withFPD_HPM1   : Boolean  = false,
+  withFPD_HP0    : Boolean  = false,
+  withFPD_HP1    : Boolean  = false,
+  withFPD_HP2    : Boolean  = false,
+  withFPD_HP3    : Boolean  = false,
+  withFPD_HPC0   : Boolean  = false,
+  withFPD_HPC1   : Boolean  = false,
+  withFPD_ACP    : Boolean  = false,
+  withFPD_ACE    : Boolean  = false,
+  withDBG_CTI0   : Boolean  = false,
+  withDBG_CTI1   : Boolean  = false,
+  withDBG_CTI2   : Boolean  = false,
+  withDBG_CTI3   : Boolean  = false,
+  withDBG_CTO0   : Boolean  = false,
+  withDBG_CTO1   : Boolean  = false,
+  withDBG_CTO2   : Boolean  = false,
+  withDBG_CTO3   : Boolean  = false,
+  withPL_PS_IRQ0 : Int      =     0,
+  withPL_PS_IRQ1 : Int      =     0,
+  withTRACE      : Boolean  = false,
   // here
   val withIO_PMOD0: Boolean = false
   ) extends UltraScalePlusConfig(
@@ -83,7 +84,7 @@ class KV260IO(config: KV260Config) extends UltraScalePlusIO(config) {
 
 class KV260(
   override val config: KV260Config = new KV260Config(
-    withPL_CLK0 = 100 MHz
+    withPL_CLK0 = PLL.IO(100 MHz)
   )
 ) extends UltraScalePlus(
   config    = config

--- a/hw/spinal/ultrascaleplus/UltraScalePlus.scala
+++ b/hw/spinal/ultrascaleplus/UltraScalePlus.scala
@@ -61,10 +61,10 @@ class UltraScalePlusConfig(
 
 class UltraScalePlusIO(config: UltraScalePlusConfig) extends Bundle {
   val pl = new Bundle {
-    val clk0 = (config.withPL_CLK0 > (0 MHz)) generate (    in(ClockResetMapped(PLL.IO, config.withPL_CLK0)))
-    val clk1 = (config.withPL_CLK1 > (0 MHz)) generate (    in(ClockResetMapped(PLL.IO, config.withPL_CLK1)))
-    val clk2 = (config.withPL_CLK2 > (0 MHz)) generate (    in(ClockResetMapped(PLL.IO, config.withPL_CLK2)))
-    val clk3 = (config.withPL_CLK3 > (0 MHz)) generate (    in(ClockResetMapped(PLL.IO, config.withPL_CLK3)))
+    val clk0 = (config.withPL_CLK0 > (0 MHz)) generate (    in(ClockResetMapped(PLL.IO(config.withPL_CLK0))))
+    val clk1 = (config.withPL_CLK1 > (0 MHz)) generate (    in(ClockResetMapped(PLL.IO(config.withPL_CLK1))))
+    val clk2 = (config.withPL_CLK2 > (0 MHz)) generate (    in(ClockResetMapped(PLL.IO(config.withPL_CLK2))))
+    val clk3 = (config.withPL_CLK3 > (0 MHz)) generate (    in(ClockResetMapped(PLL.IO(config.withPL_CLK3))))
   }
   val lpd = new Bundle {
     val hp0  = (config.withLPD_HP0          ) generate (master(Axi4Mapped(LPD.HP0 )))

--- a/hw/spinal/ultrascaleplus/UltraScalePlus.scala
+++ b/hw/spinal/ultrascaleplus/UltraScalePlus.scala
@@ -28,75 +28,75 @@ import ultrascaleplus.utils._
 
 
 class UltraScalePlusConfig(
-  val withPL_CLK0    : HertzNumber = 100 MHz,
-  val withPL_CLK1    : HertzNumber =   0 MHz,
-  val withPL_CLK2    : HertzNumber =   0 MHz,
-  val withPL_CLK3    : HertzNumber =   0 MHz,
-  val withLPD_HPM0   : Boolean     = false,
-  val withLPD_HP0    : Boolean     = false,
-  val withFPD_HPM0   : Boolean     = false,
-  val withFPD_HPM1   : Boolean     = false,
-  val withFPD_HP0    : Boolean     = false,
-  val withFPD_HP1    : Boolean     = false,
-  val withFPD_HP2    : Boolean     = false,
-  val withFPD_HP3    : Boolean     = false,
-  val withFPD_HPC0   : Boolean     = false,
-  val withFPD_HPC1   : Boolean     = false,
-  val withFPD_ACP    : Boolean     = false,
-  val withFPD_ACE    : Boolean     = false,
-  val withDBG_CTI0   : Boolean     = false,
-  val withDBG_CTI1   : Boolean     = false,
-  val withDBG_CTI2   : Boolean     = false,
-  val withDBG_CTI3   : Boolean     = false,
-  val withDBG_CTO0   : Boolean     = false,
-  val withDBG_CTO1   : Boolean     = false,
-  val withDBG_CTO2   : Boolean     = false,
-  val withDBG_CTO3   : Boolean     = false,
-  val withPL_PS_IRQ0 : Int         =     0,
-  val withPL_PS_IRQ1 : Int         =     0,
-  val withTRACE      : Boolean     = false
+  val withPL_CLK0    : PLL     = PLL.IO(100 MHz),
+  val withPL_CLK1    : PLL     = PLL.IO(  0 MHz),
+  val withPL_CLK2    : PLL     = PLL.IO(  0 MHz),
+  val withPL_CLK3    : PLL     = PLL.IO(  0 MHz),
+  val withLPD_HPM0   : Boolean = false,
+  val withLPD_HP0    : Boolean = false,
+  val withFPD_HPM0   : Boolean = false,
+  val withFPD_HPM1   : Boolean = false,
+  val withFPD_HP0    : Boolean = false,
+  val withFPD_HP1    : Boolean = false,
+  val withFPD_HP2    : Boolean = false,
+  val withFPD_HP3    : Boolean = false,
+  val withFPD_HPC0   : Boolean = false,
+  val withFPD_HPC1   : Boolean = false,
+  val withFPD_ACP    : Boolean = false,
+  val withFPD_ACE    : Boolean = false,
+  val withDBG_CTI0   : Boolean = false,
+  val withDBG_CTI1   : Boolean = false,
+  val withDBG_CTI2   : Boolean = false,
+  val withDBG_CTI3   : Boolean = false,
+  val withDBG_CTO0   : Boolean = false,
+  val withDBG_CTO1   : Boolean = false,
+  val withDBG_CTO2   : Boolean = false,
+  val withDBG_CTO3   : Boolean = false,
+  val withPL_PS_IRQ0 : Int     =     0,
+  val withPL_PS_IRQ1 : Int     =     0,
+  val withTRACE      : Boolean = false
   ) {
 }
 
 
 class UltraScalePlusIO(config: UltraScalePlusConfig) extends Bundle {
   val pl = new Bundle {
-    val clk0 = (config.withPL_CLK0 > (0 MHz)) generate (    in(ClockResetMapped(PLL.IO(config.withPL_CLK0))))
-    val clk1 = (config.withPL_CLK1 > (0 MHz)) generate (    in(ClockResetMapped(PLL.IO(config.withPL_CLK1))))
-    val clk2 = (config.withPL_CLK2 > (0 MHz)) generate (    in(ClockResetMapped(PLL.IO(config.withPL_CLK2))))
-    val clk3 = (config.withPL_CLK3 > (0 MHz)) generate (    in(ClockResetMapped(PLL.IO(config.withPL_CLK3))))
+    val clk0 = (config.withPL_CLK0.enabled) generate (    in(ClockResetMapped(config.withPL_CLK0)))
+    val clk1 = (config.withPL_CLK1.enabled) generate (    in(ClockResetMapped(config.withPL_CLK1)))
+    val clk2 = (config.withPL_CLK2.enabled) generate (    in(ClockResetMapped(config.withPL_CLK2)))
+    val clk3 = (config.withPL_CLK3.enabled) generate (    in(ClockResetMapped(config.withPL_CLK3)))
   }
   val lpd = new Bundle {
-    val hp0  = (config.withLPD_HP0          ) generate (master(Axi4Mapped(LPD.HP0 )))
-    val hpm0 = (config.withLPD_HPM0         ) generate ( slave(Axi4Mapped(LPD.HPM0)))
+    val hp0  = (config.withLPD_HP0        ) generate (master(Axi4Mapped(LPD.HP0 )))
+    val hpm0 = (config.withLPD_HPM0       ) generate ( slave(Axi4Mapped(LPD.HPM0)))
   }
   val fpd = new Bundle {
-    val hpm0 = (config.withFPD_HPM0         ) generate ( slave(Axi4Mapped(FPD.HPM0)))
-    val hpm1 = (config.withFPD_HPM1         ) generate ( slave(Axi4Mapped(FPD.HPM1)))
-    val hp0  = (config.withFPD_HP0          ) generate (master(Axi4Mapped(FPD.HP0 )))
-    val hp1  = (config.withFPD_HP1          ) generate (master(Axi4Mapped(FPD.HP1 )))
-    val hp2  = (config.withFPD_HP2          ) generate (master(Axi4Mapped(FPD.HP2 )))
-    val hp3  = (config.withFPD_HP3          ) generate (master(Axi4Mapped(FPD.HP3 )))
-    val hpc0 = (config.withFPD_HPC0         ) generate (master(Axi4Mapped(FPD.HPC0)))
-    val hpc1 = (config.withFPD_HPC1         ) generate (master(Axi4Mapped(FPD.HPC1)))
-    val acp  = (config.withFPD_ACP          ) generate (master(Axi4Mapped(FPD.ACP )))
+    val hpm0 = (config.withFPD_HPM0       ) generate ( slave(Axi4Mapped(FPD.HPM0)))
+    val hpm1 = (config.withFPD_HPM1       ) generate ( slave(Axi4Mapped(FPD.HPM1)))
+    val hp0  = (config.withFPD_HP0        ) generate (master(Axi4Mapped(FPD.HP0 )))
+    val hp1  = (config.withFPD_HP1        ) generate (master(Axi4Mapped(FPD.HP1 )))
+    val hp2  = (config.withFPD_HP2        ) generate (master(Axi4Mapped(FPD.HP2 )))
+    val hp3  = (config.withFPD_HP3        ) generate (master(Axi4Mapped(FPD.HP3 )))
+    val hpc0 = (config.withFPD_HPC0       ) generate (master(Axi4Mapped(FPD.HPC0)))
+    val hpc1 = (config.withFPD_HPC1       ) generate (master(Axi4Mapped(FPD.HPC1)))
+    val acp  = (config.withFPD_ACP        ) generate (master(Axi4Mapped(FPD.ACP )))
 //  val fpd_ace  = (withFPD_ACE    ) generate ( slave(Axi4(KriaPorts.FPD_ACE_Config )))
   }
   val dbg = new Bundle {
-    val cti0 = (config.withDBG_CTI0         ) generate ( slave(CrossTrigger()))
-    val cti1 = (config.withDBG_CTI1         ) generate ( slave(CrossTrigger()))
-    val cti2 = (config.withDBG_CTI2         ) generate ( slave(CrossTrigger()))
-    val cti3 = (config.withDBG_CTI3         ) generate ( slave(CrossTrigger()))
-    val cto0 = (config.withDBG_CTO0         ) generate (master(CrossTrigger()))
-    val cto1 = (config.withDBG_CTO1         ) generate (master(CrossTrigger()))
-    val cto2 = (config.withDBG_CTO2         ) generate (master(CrossTrigger()))
-    val cto3 = (config.withDBG_CTO3         ) generate (master(CrossTrigger()))
+    val cti0 = (config.withDBG_CTI0       ) generate ( slave(CrossTrigger()))
+    val cti1 = (config.withDBG_CTI1       ) generate ( slave(CrossTrigger()))
+    val cti2 = (config.withDBG_CTI2       ) generate ( slave(CrossTrigger()))
+    val cti3 = (config.withDBG_CTI3       ) generate ( slave(CrossTrigger()))
+    val cto0 = (config.withDBG_CTO0       ) generate (master(CrossTrigger()))
+    val cto1 = (config.withDBG_CTO1       ) generate (master(CrossTrigger()))
+    val cto2 = (config.withDBG_CTO2       ) generate (master(CrossTrigger()))
+    val cto3 = (config.withDBG_CTO3       ) generate (master(CrossTrigger()))
   }
   val irq = new Bundle {
-    val toPS0 = (config.withPL_PS_IRQ0 > 0  ) generate (out(IRQ(config.withPL_PS_IRQ0)))
-    val toPS1 = (config.withPL_PS_IRQ1 > 0  ) generate (out(IRQ(config.withPL_PS_IRQ1)))
+    val toPS0 = (config.withPL_PS_IRQ0 > 0) generate (out(IRQ(config.withPL_PS_IRQ0)))
+    val toPS1 = (config.withPL_PS_IRQ1 > 0) generate (out(IRQ(config.withPL_PS_IRQ1)))
   }
-  val trace = (config.withTRACE             ) generate ( in(Trace(32)))
+  val trace = (config.withTRACE           ) generate ( in(Trace(32)))
 }
 
 
@@ -361,22 +361,22 @@ abstract class UltraScalePlus (
     tcl += "  CONFIG.PSU__CRL_APB__PCAP_CTRL__ACT_FREQMHZ {199.998001} \\\n"
     tcl += "  CONFIG.PSU__CRL_APB__PCAP_CTRL__FREQMHZ {200} \\\n"
     tcl += "  CONFIG.PSU__CRL_APB__PCAP_CTRL__SRCSEL {IOPLL} \\\n"
-    if (config.withPL_CLK0 > (0 MHz)) {
+    if (config.withPL_CLK0.enabled) {
       tcl +=f"  CONFIG.PSU__CRL_APB__PL0_REF_CTRL__ACT_FREQMHZ {${this.io.pl.clk0.frequency.decompose._1}} \\\n"
       tcl +=f"  CONFIG.PSU__CRL_APB__PL0_REF_CTRL__FREQMHZ {${this.io.pl.clk0.frequency.decompose._1}} \\\n"
       tcl +=f"  CONFIG.PSU__CRL_APB__PL0_REF_CTRL__SRCSEL {${this.io.pl.clk0.source.name}} \\\n"
     }
-    if (config.withPL_CLK1 > (0 MHz)) {
+    if (config.withPL_CLK1.enabled) {
       tcl +=f"  CONFIG.PSU__CRL_APB__PL1_REF_CTRL__ACT_FREQMHZ {${this.io.pl.clk1.frequency.decompose._1}} \\\n"
       tcl +=f"  CONFIG.PSU__CRL_APB__PL1_REF_CTRL__FREQMHZ {${this.io.pl.clk1.frequency.decompose._1}} \\\n"
       tcl +=f"  CONFIG.PSU__CRL_APB__PL1_REF_CTRL__SRCSEL {${this.io.pl.clk1.source.name}} \\\n"
     }
-    if (config.withPL_CLK2 > (0 MHz)) {
+    if (config.withPL_CLK2.enabled) {
       tcl +=f"  CONFIG.PSU__CRL_APB__PL2_REF_CTRL__ACT_FREQMHZ {${this.io.pl.clk2.frequency.decompose._1}} \\\n"
       tcl +=f"  CONFIG.PSU__CRL_APB__PL2_REF_CTRL__FREQMHZ {${this.io.pl.clk2.frequency.decompose._1}} \\\n"
       tcl +=f"  CONFIG.PSU__CRL_APB__PL2_REF_CTRL__SRCSEL {${this.io.pl.clk2.source.name}} \\\n"
     }
-    if (config.withPL_CLK3 > (0 MHz)) {
+    if (config.withPL_CLK3.enabled) {
       tcl +=f"  CONFIG.PSU__CRL_APB__PL3_REF_CTRL__ACT_FREQMHZ {${this.io.pl.clk3.frequency.decompose._1}} \\\n"
       tcl +=f"  CONFIG.PSU__CRL_APB__PL3_REF_CTRL__FREQMHZ {${this.io.pl.clk3.frequency.decompose._1}} \\\n"
       tcl +=f"  CONFIG.PSU__CRL_APB__PL3_REF_CTRL__SRCSEL {${this.io.pl.clk3.source.name}} \\\n"
@@ -430,10 +430,10 @@ abstract class UltraScalePlus (
     tcl += "  CONFIG.PSU__DDR_HIGH_ADDRESS_GUI_ENABLE {1} \\\n"
     tcl += "  CONFIG.PSU__DDR__INTERFACE__FREQMHZ {600.000} \\\n"
     tcl += "  CONFIG.PSU__FPD_SLCR__WDT1__ACT_FREQMHZ {99.999001} \\\n"
-    tcl +=f"  CONFIG.PSU__FPGA_PL0_ENABLE {${(config.withPL_CLK0 > (0 MHz)).toInt}} \\\n"
-    tcl +=f"  CONFIG.PSU__FPGA_PL1_ENABLE {${(config.withPL_CLK1 > (0 MHz)).toInt}} \\\n"
-    tcl +=f"  CONFIG.PSU__FPGA_PL2_ENABLE {${(config.withPL_CLK2 > (0 MHz)).toInt}} \\\n"
-    tcl +=f"  CONFIG.PSU__FPGA_PL3_ENABLE {${(config.withPL_CLK3 > (0 MHz)).toInt}} \\\n"
+    tcl +=f"  CONFIG.PSU__FPGA_PL0_ENABLE {${(config.withPL_CLK0.enabled).toInt}} \\\n"
+    tcl +=f"  CONFIG.PSU__FPGA_PL1_ENABLE {${(config.withPL_CLK1.enabled).toInt}} \\\n"
+    tcl +=f"  CONFIG.PSU__FPGA_PL2_ENABLE {${(config.withPL_CLK2.enabled).toInt}} \\\n"
+    tcl +=f"  CONFIG.PSU__FPGA_PL3_ENABLE {${(config.withPL_CLK3.enabled).toInt}} \\\n"
     tcl +=f"  CONFIG.PSU__FTM__CTI_IN_0 {${config.withDBG_CTI0.toInt}} \\\n"
     tcl +=f"  CONFIG.PSU__FTM__CTI_IN_1 {${config.withDBG_CTI1.toInt}} \\\n"
     tcl +=f"  CONFIG.PSU__FTM__CTI_IN_2 {${config.withDBG_CTI2.toInt}} \\\n"
@@ -467,10 +467,10 @@ abstract class UltraScalePlus (
       tcl += "  CONFIG.PSU__MAXIGP2__DATA_WIDTH {128} \\\n"
     tcl += "  CONFIG.PSU__NUM_FABRIC_RESETS {4} \\\n"
     tcl += "  CONFIG.PSU__OVERRIDE__BASIC_CLOCK {0} \\\n"
-    tcl += "  CONFIG.PSU__PL_CLK0_BUF {"+(if (config.withPL_CLK0 > (0 MHz)) "True" else "False")+"} \\\n"
-    tcl += "  CONFIG.PSU__PL_CLK1_BUF {"+(if (config.withPL_CLK1 > (0 MHz)) "True" else "False")+"} \\\n"
-    tcl += "  CONFIG.PSU__PL_CLK2_BUF {"+(if (config.withPL_CLK2 > (0 MHz)) "True" else "False")+"} \\\n"
-    tcl += "  CONFIG.PSU__PL_CLK3_BUF {"+(if (config.withPL_CLK3 > (0 MHz)) "True" else "False")+"} \\\n"
+    tcl += "  CONFIG.PSU__PL_CLK0_BUF {"+(if (config.withPL_CLK0.enabled) "True" else "False")+"} \\\n"
+    tcl += "  CONFIG.PSU__PL_CLK1_BUF {"+(if (config.withPL_CLK1.enabled) "True" else "False")+"} \\\n"
+    tcl += "  CONFIG.PSU__PL_CLK2_BUF {"+(if (config.withPL_CLK2.enabled) "True" else "False")+"} \\\n"
+    tcl += "  CONFIG.PSU__PL_CLK3_BUF {"+(if (config.withPL_CLK3.enabled) "True" else "False")+"} \\\n"
     tcl += "  CONFIG.PSU__PMU_COHERENCY {0} \\\n"
     tcl += "  CONFIG.PSU__PMU__AIBACK__ENABLE {0} \\\n"
     tcl += "  CONFIG.PSU__PMU__EMIO_GPI__ENABLE {0} \\\n"

--- a/hw/spinal/ultrascaleplus/Vivado.scala
+++ b/hw/spinal/ultrascaleplus/Vivado.scala
@@ -278,7 +278,6 @@ object Vivado {
     }
     
     def fill(mode: String): Unit = {
-      println(f"${this.target}/${mode}.json")
       this.fill(os.pwd / "hw" / "ext" / "Vivado" / Vivado.year / f"${this.target}" / f"${mode}.json")
     }
 

--- a/hw/spinal/ultrascaleplus/clock/Clock.scala
+++ b/hw/spinal/ultrascaleplus/clock/Clock.scala
@@ -5,14 +5,14 @@ import spinal.core._
 import spinal.lib._
 
 
-import ultrascaleplus.clock.pll.PllSource
+import ultrascaleplus.clock.pll._
 import ultrascaleplus.utils.{TCL, XDC, PSPLInterface, Log, Util}
 import ultrascaleplus.scripts.{TCLFactory}
 
 
 object ClockMapped {
 
-  def apply(source: PllSource, target: HertzNumber): ClockMapped = new ClockMapped(source, target)
+  def apply(source: PLL): ClockMapped = new ClockMapped(source)
 
 }
 
@@ -20,22 +20,23 @@ object ClockMapped {
  *
  *  @constructor Creates a mappable clock source.
  *  @parameter source PLL clock source.
- *  @parameter target Target frequency desired.
  */
-class ClockMapped(val source: PllSource, val target: HertzNumber) extends Bundle with PSPLInterface with TCL {
+class ClockMapped(val source: PLL) extends Bundle with PSPLInterface with TCL {
 
   val clock = in(Bool())
 
-  val frequency = source.round(target)
-  Log.info(f"[${this.source.name}] ${this.target} requested but ${this.frequency} selected.")
-
   val domain = ClockDomain(
     clock     = this.clock,
-    frequency = FixedFrequency(this.frequency), 
+    frequency = FixedFrequency(source.frequency), 
     config    = ClockDomainConfig(
       clockEdge        = RISING
     )
   )
+
+  /**
+   * Abstracts access to the PLL source frequency.
+   */
+  def frequency: HertzNumber = source.frequency
 
   override def getTCL(): String = {
     val topmodule = Util.topmodule(this)

--- a/hw/spinal/ultrascaleplus/clock/ClockResetMapped.scala
+++ b/hw/spinal/ultrascaleplus/clock/ClockResetMapped.scala
@@ -5,14 +5,14 @@ import spinal.core._
 import spinal.lib._
 
 
-import ultrascaleplus.clock.pll.PllSource
+import ultrascaleplus.clock.pll._
 import ultrascaleplus.utils.{TCL, XDC, PSPLInterface, Log, Util}
 import ultrascaleplus.scripts.{TCLFactory}
 
 
 object ClockResetMapped {
 
-  def apply(source: PllSource, target: HertzNumber): ClockResetMapped = new ClockResetMapped(source, target)
+  def apply(source: PLL): ClockResetMapped = new ClockResetMapped(source)
 
 }
 
@@ -20,16 +20,15 @@ object ClockResetMapped {
  *
  *  @constructor Creates a mappable clock source.
  *  @parameter source PLL clock source.
- *  @parameter target Target frequency desired.
  */
-class ClockResetMapped(source: PllSource, target: HertzNumber) extends ClockMapped(source: PllSource, target: HertzNumber) {
+class ClockResetMapped(source: PLL) extends ClockMapped(source) {
   
   val reset = in(Bool())
 
   override val domain = ClockDomain(
     clock     = this.clock,
     reset     = this.reset,
-    frequency = FixedFrequency(this.frequency), 
+    frequency = FixedFrequency(source.frequency), 
     config    = ClockDomainConfig(
       clockEdge        = RISING,
       resetKind        = ASYNC,

--- a/hw/spinal/ultrascaleplus/clock/Pll.scala
+++ b/hw/spinal/ultrascaleplus/clock/Pll.scala
@@ -5,29 +5,26 @@ import spinal.core._
 import spinal.lib._
 
 
-abstract class PllSource() {
+import ultrascaleplus.utils.Log
 
-  val name: String
 
-  val frequencies: Seq[HertzNumber]
-
-  def round(target: HertzNumber): HertzNumber = {
-    val differences = frequencies.map(x => (x-target).toDouble).map(x => if (x > 0) -1.0/0 else x)
-    val index       = differences.indexOf(differences.max)
-    return frequencies(index)
-  }
-
-}
+case class PLL(name: String, frequency: HertzNumber) {}
 
 
 object PLL {
 
-  object IO extends PllSource() {
+  object IO {
 
-    override val name = "IOPLL"
+    val frequencies = Seq(333.329987 MHz, 299.997009 MHz, 249.997498 MHz, 199.998001 MHz, 142.855713 MHz, 99.999001 MHz, 49.999500 MHz)
 
-    override val frequencies = Seq(333.329987 MHz, 299.997009 MHz, 249.997498 MHz, 199.998001 MHz, 142.855713 MHz, 99.999001 MHz, 49.999500 MHz)
+    def apply(target: HertzNumber): PLL = {
+      val differences = frequencies.map(x => (x-target).toDouble).map(x => if (x > 0) -1.0/0 else x)
+      val index       = differences.indexOf(differences.max)
+      Log.info(f"[IOPLL] ${target} requested but ${frequencies(index)} selected.")
+      return PLL("IOPLL", frequencies(index))
+    }
 
   }
 
 }
+

--- a/hw/spinal/ultrascaleplus/clock/Pll.scala
+++ b/hw/spinal/ultrascaleplus/clock/Pll.scala
@@ -1,6 +1,9 @@
 package ultrascaleplus.clock.pll
 
 
+import scala.math.{floor, ceil, round, pow}
+
+
 import spinal.core._
 import spinal.lib._
 
@@ -19,44 +22,59 @@ case class PLL(name: String, frequency: HertzNumber) {
 
 object PLL {
 
-  case class Config(m: Int, d0: Int, d1: Int, d2: Int, fvco: HertzNumber, fout: HertzNumber) {}
+  case class Config(m: Int, d0: Int, d1: Int, d2: Int, fvco: HertzNumber) {
+
+    val fout: HertzNumber = fvco/(2*d0*d1*d2)
+
+  }
 
   case class Ranges(m: Range, d0: Range, d1: Range) {}
 
   private def quantize(frequency: HertzNumber, scale: Int = 6): HertzNumber = {
     return HertzNumber(frequency.toBigDecimal.setScale(scale, BigDecimal.RoundingMode.HALF_UP))
   }
+
+  private def clamp(value: Int, range: Range): Int = {
+    return (value max range.min) min range.max
+  }
  
   /**
-   * Branch and bound. Looking for best match
+   * Branch and bound. Looking for best match.
+   *
+   * Mix of logic found from xilinx sources:
+   *  - https://github.com/Xilinx/linux-xlnx/blob/786191c466220b9fe979f81053b82cb095d18225/drivers/clk/zynqmp/pll.c#L101
+   *  - https://github.com/Xilinx/embeddedsw/blob/45a18907084e77bb3a450a035d280130d7ff6e26/lib/sw_services/xilpm/src/zynqmp/client/common/pm_clock.c#L1107
    */
   def tune(fin: HertzNumber, target: HertzNumber, ranges: Ranges): PLL.Config = {
-    var bestConfig: PLL.Config  = null
-    var bestError : HertzNumber = HertzNumber(Double.MinValue)
-
-    for {
-      d1 <- ranges.d1
-      d0 <- ranges.d0
-      m  <- ranges.m
-    } {
-      val fvco = fin*m
-      // Detect if div2 is needed
-      val div2 = if((fvco/target) > ranges.d0.max*ranges.d1.max) Seq(1, 2, 4, 8) else Seq(1)
-      // Search
-      for (d2 <- div2) {
-        // Reportedly, there is a fixed /2 factor
-        val fout = PLL.quantize(fvco/(2*d0*d1*d2))
-        // Note error must be the smallest non strictly positive frequency
-        val error = fout-target
-        if ((error <= HertzNumber(0)) && (bestError < error)) {
-          bestError = error
-          bestConfig = PLL.Config(m, d0, d1, d2, fvco, fout)
-          println(f"${error} -> Config(${m}, ${d0}, ${d1}, ${d2}, ${fvco}, ${fout})")
-        }
-      }
+    val divRange = (0 to 63)
+    var config: Option[PLL.Config] = None
+    val m = 90
+    val fvco = fin.toDouble*m
+    val div = ceil(fvco/(2*target.toDouble)).toInt
+    // Breakdown overall divisor in two divisors
+    assert(
+      assertion = div < pow(divRange.max, 2),
+      message   = f"Rate (${fvco}) must be smaller than ${pow(2, divRange.max)}!"
+    )
+    // Fits in first divisor -> straight forward mapping
+    if (divRange contains div) {
+      config = Some(PLL.Config(m, div.toInt, 1, 1, HertzNumber(fvco)))
     }
-
-    return bestConfig
+    // Must be decomposed
+    else {
+      val decomposition = (2 to ceil(divRange.max/2).toInt).filter(d0 => fvco%d0 == 0).map(d0 => (d0, floor(fvco.toLong/d0).toInt))
+      assert(
+        assertion = decomposition(0)._2 != 0,
+        message   = "Divisor is a prime number bigger than the encoding width."
+      )
+      config = Some(PLL.Config(m, decomposition(0)._1, decomposition(0)._2, 1, HertzNumber(fvco)))
+    }
+    assert(
+      assertion = config.isDefined,
+      message   = f"No PLL configuration could not be found for target ${target}."
+    )
+    println(f"Config(${config.get.m}, ${config.get.d0}, ${config.get.d1}, ${config.get.d2}, ${config.get.fvco}, ${config.get.fout})")
+    return config.get
   }
 
   object IO {

--- a/hw/spinal/ultrascaleplus/clock/Pll.scala
+++ b/hw/spinal/ultrascaleplus/clock/Pll.scala
@@ -11,11 +11,35 @@ import spinal.lib._
 import ultrascaleplus.utils.Log
 
 
-case class PLL(name: String, frequency: HertzNumber) {
+case class PLL(val name: String, target: HertzNumber, mapping: Map[Int, Seq[HertzNumber]]) {
+
+  private var multiplier: Int = 0
+
+  var frequency : HertzNumber = 0 MHz
 
   def enabled: Boolean = {
     return this.frequency > HertzNumber(0)
   }
+
+  private def round(target: HertzNumber, frequencies: Seq[HertzNumber]): HertzNumber = {
+    val differences = frequencies.map(x => (x-target).toDouble).map(x => if (x > 0) -1.0/0 else x)
+    val index       = differences.indexOf(differences.max)
+    return frequencies(index)
+  }
+
+  // If target is 0 MHz, then disabled
+  if (target != (0 MHz)) {
+    // For all multiplier, pick one giving best target frequency fit
+    for (frequencies <- mapping) {
+      val estimation = round(target, frequencies._2)
+      if (target-estimation < target-frequency) {
+        multiplier = frequencies._1
+        frequency  = estimation
+      }
+    }
+  }
+  
+  Log.info(f"[${name}] ${target} requested but ${frequency} selected.")
 
 }
 
@@ -30,14 +54,6 @@ object PLL {
 
   case class Ranges(m: Range, d0: Range, d1: Range) {}
 
-  private def quantize(frequency: HertzNumber, scale: Int = 6): HertzNumber = {
-    return HertzNumber(frequency.toBigDecimal.setScale(scale, BigDecimal.RoundingMode.HALF_UP))
-  }
-
-  private def clamp(value: Int, range: Range): Int = {
-    return (value max range.min) min range.max
-  }
- 
   /**
    * Branch and bound. Looking for best match.
    *
@@ -79,18 +95,27 @@ object PLL {
 
   object IO {
 
-    val frequencies = Seq(333.329987 MHz, 299.997009 MHz, 249.997498 MHz, 199.998001 MHz, 142.855713 MHz, 99.999001 MHz, 49.999500 MHz)
-
-    //val ranges = Ranges(45 to 90, 1 to 63, 1 to 63)
-    val ranges = Ranges(60 to 90 by 30, 1 to 63, 1 to 63)
+    val mapping: Map[Int, Seq[HertzNumber]] = Map(
+      60 -> Seq(333.329987 MHz, 249.997498 MHz, 199.998001 MHz, 142.855713 MHz, 99.999001 MHz, 71.427856 MHz, 49.999500 MHz),
+      90 -> Seq(299.997009 MHz,  74.999252 MHz)
+    )
 
     def apply(target: HertzNumber): PLL = {
-      val frequency = PLL.tune(33.333333 MHz, target, ranges).fout
-      Log.info(f"[IOPLL] ${target} requested but ${frequency} selected.")
-      return PLL("IOPLL", frequency)
+      return new PLL("IOPLL", target, mapping)
     }
 
   }
 
+  object R {
+
+    val mapping: Map[Int, Seq[HertzNumber]] = Map(
+      63 -> Seq(74.999252 MHz)
+    )
+
+    def apply(target: HertzNumber): PLL = {
+      return new PLL("RPLL", target, mapping)
+    }
+
+  }
 }
 

--- a/hw/spinal/ultrascaleplus/clock/Pll.scala
+++ b/hw/spinal/ultrascaleplus/clock/Pll.scala
@@ -8,7 +8,13 @@ import spinal.lib._
 import ultrascaleplus.utils.Log
 
 
-case class PLL(name: String, frequency: HertzNumber) {}
+case class PLL(name: String, frequency: HertzNumber) {
+
+  def enabled: Boolean = {
+    return this.frequency > HertzNumber(0)
+  }
+
+}
 
 
 object PLL {
@@ -16,6 +22,10 @@ object PLL {
   case class Config(m: Int, d0: Int, d1: Int, d2: Int, fvco: HertzNumber, fout: HertzNumber) {}
 
   case class Ranges(m: Range, d0: Range, d1: Range) {}
+
+  private def quantize(frequency: HertzNumber, scale: Int = 6): HertzNumber = {
+    return HertzNumber(frequency.toBigDecimal.setScale(scale, BigDecimal.RoundingMode.HALF_UP))
+  }
  
   /**
    * Branch and bound. Looking for best match
@@ -35,7 +45,7 @@ object PLL {
       // Search
       for (d2 <- div2) {
         // Reportedly, there is a fixed /2 factor
-        val fout = fvco/(2*d0*d1*d2)
+        val fout = PLL.quantize(fvco/(2*d0*d1*d2))
         // Note error must be the smallest non strictly positive frequency
         val error = fout-target
         if ((error <= HertzNumber(0)) && (bestError < error)) {

--- a/hw/spinal/ultrascaleplus/clock/Pll.scala
+++ b/hw/spinal/ultrascaleplus/clock/Pll.scala
@@ -13,15 +13,53 @@ case class PLL(name: String, frequency: HertzNumber) {}
 
 object PLL {
 
+  case class Config(m: Int, d0: Int, d1: Int, d2: Int, fvco: HertzNumber, fout: HertzNumber) {}
+
+  case class Ranges(m: Range, d0: Range, d1: Range) {}
+ 
+  /**
+   * Branch and bound. Looking for best match
+   */
+  def tune(fin: HertzNumber, target: HertzNumber, ranges: Ranges): PLL.Config = {
+    var bestConfig: PLL.Config  = null
+    var bestError : HertzNumber = HertzNumber(Double.MinValue)
+
+    for {
+      d1 <- ranges.d1
+      d0 <- ranges.d0
+      m  <- ranges.m
+    } {
+      val fvco = fin*m
+      // Detect if div2 is needed
+      val div2 = if((fvco/target) > ranges.d0.max*ranges.d1.max) Seq(1, 2, 4, 8) else Seq(1)
+      // Search
+      for (d2 <- div2) {
+        // Reportedly, there is a fixed /2 factor
+        val fout = fvco/(2*d0*d1*d2)
+        // Note error must be the smallest non strictly positive frequency
+        val error = fout-target
+        if ((error <= HertzNumber(0)) && (bestError < error)) {
+          bestError = error
+          bestConfig = PLL.Config(m, d0, d1, d2, fvco, fout)
+          println(f"${error} -> Config(${m}, ${d0}, ${d1}, ${d2}, ${fvco}, ${fout})")
+        }
+      }
+    }
+
+    return bestConfig
+  }
+
   object IO {
 
     val frequencies = Seq(333.329987 MHz, 299.997009 MHz, 249.997498 MHz, 199.998001 MHz, 142.855713 MHz, 99.999001 MHz, 49.999500 MHz)
 
+    //val ranges = Ranges(45 to 90, 1 to 63, 1 to 63)
+    val ranges = Ranges(60 to 90 by 30, 1 to 63, 1 to 63)
+
     def apply(target: HertzNumber): PLL = {
-      val differences = frequencies.map(x => (x-target).toDouble).map(x => if (x > 0) -1.0/0 else x)
-      val index       = differences.indexOf(differences.max)
-      Log.info(f"[IOPLL] ${target} requested but ${frequencies(index)} selected.")
-      return PLL("IOPLL", frequencies(index))
+      val frequency = PLL.tune(33.333333 MHz, target, ranges).fout
+      Log.info(f"[IOPLL] ${target} requested but ${frequency} selected.")
+      return PLL("IOPLL", frequency)
     }
 
   }

--- a/hw/spinal/zcu102/ZCU102.scala
+++ b/hw/spinal/zcu102/ZCU102.scala
@@ -13,40 +13,41 @@ import ultrascaleplus.bus.amba.axi4._
 import ultrascaleplus.io.pmod._
 import ultrascaleplus.scripts._
 import ultrascaleplus.clock.PLClockingArea
+import ultrascaleplus.clock.pll._
 
 import zcu102.io.pmod._
 import zcu102.clock._
 
 
 class ZCU102Config(
-  withPL_CLK0      : HertzNumber = 100 MHz,
-  withPL_CLK1      : HertzNumber =   0 MHz,
-  withPL_CLK2      : HertzNumber =   0 MHz,
-  withPL_CLK3      : HertzNumber =   0 MHz,
-  withLPD_HPM0     : Boolean     = false,
-  withLPD_HP0      : Boolean     = false,
-  withFPD_HPM0     : Boolean     = false,
-  withFPD_HPM1     : Boolean     = false,
-  withFPD_HP0      : Boolean     = false,
-  withFPD_HP1      : Boolean     = false,
-  withFPD_HP2      : Boolean     = false,
-  withFPD_HP3      : Boolean     = false,
-  withFPD_HPC0     : Boolean     = false,
-  withFPD_HPC1     : Boolean     = false,
-  withFPD_ACP      : Boolean     = false,
-  withFPD_ACE      : Boolean     = false,
-  withDBG_CTI0     : Boolean     = false,
-  withDBG_CTI1     : Boolean     = false,
-  withDBG_CTI2     : Boolean     = false,
-  withDBG_CTI3     : Boolean     = false,
-  withDBG_CTO0     : Boolean     = false,
-  withDBG_CTO1     : Boolean     = false,
-  withDBG_CTO2     : Boolean     = false,
-  withDBG_CTO3     : Boolean     = false,
-  withPL_PS_IRQ0   : Int         =     0,
-  withPL_PS_IRQ1   : Int         =     0,
-  withTRACE        : Boolean     = false,
-  val withSI570_MGT: HertzNumber =   0 MHz
+  withPL_CLK0       : PLL         = PLL.IO(100 MHz),
+  withPL_CLK1       : PLL         = PLL.IO(  0 MHz),
+  withPL_CLK2       : PLL         = PLL.IO(  0 MHz),
+  withPL_CLK3       : PLL         = PLL.IO(  0 MHz),
+  withLPD_HPM0      : Boolean     = false,
+  withLPD_HP0       : Boolean     = false,
+  withFPD_HPM0      : Boolean     = false,
+  withFPD_HPM1      : Boolean     = false,
+  withFPD_HP0       : Boolean     = false,
+  withFPD_HP1       : Boolean     = false,
+  withFPD_HP2       : Boolean     = false,
+  withFPD_HP3       : Boolean     = false,
+  withFPD_HPC0      : Boolean     = false,
+  withFPD_HPC1      : Boolean     = false,
+  withFPD_ACP       : Boolean     = false,
+  withFPD_ACE       : Boolean     = false,
+  withDBG_CTI0      : Boolean     = false,
+  withDBG_CTI1      : Boolean     = false,
+  withDBG_CTI2      : Boolean     = false,
+  withDBG_CTI3      : Boolean     = false,
+  withDBG_CTO0      : Boolean     = false,
+  withDBG_CTO1      : Boolean     = false,
+  withDBG_CTO2      : Boolean     = false,
+  withDBG_CTO3      : Boolean     = false,
+  withPL_PS_IRQ0    : Int         =     0,
+  withPL_PS_IRQ1    : Int         =     0,
+  withTRACE         : Boolean     = false,
+  val withSI570_MGT : HertzNumber =   0 MHz
   ) extends UltraScalePlusConfig(
     withPL_CLK0    = withPL_CLK0   ,
     withPL_CLK1    = withPL_CLK1   ,
@@ -89,7 +90,7 @@ class ZCU102IO(config: ZCU102Config) extends UltraScalePlusIO(config) {
 
 class ZCU102(
   override val config   : ZCU102Config = new ZCU102Config(
-    withPL_CLK0 = 100 MHz
+    withPL_CLK0 = PLL.IO(100 MHz)
   )
 ) extends UltraScalePlus(
   config    = config


### PR DESCRIPTION
User can now pick between IOPLL and RPLL as source.

This can be done as simply as calling the respective factories in the board IO configuration:
```scala
PLL.IO(X MHz)
PLL.R(Y MHz)
```

See the examples design for a full overview.

Changes are mostly in the backend. Only a know set of values are supported for the moment.

**WARNING:**
There is a know unhandle case. PL clocks using the same source (in particular IOPLL)  maybe dependent on the other ones. Current version does not detect, raise an error, nor raise a warning. Please double check the vivado design in case of a doubt. 